### PR TITLE
Implement Color Customization on Settings Menu

### DIFF
--- a/src/controllers/viewsController.js
+++ b/src/controllers/viewsController.js
@@ -149,7 +149,8 @@ const getNavMenu = async (req, res, next) => {
 const getSettings = async (req, res, next) => {
     try {
         let featureFlags = await helpers.retrieveFeatureFlags();
-        res.status(200).render('settings', { page: 'settings', featureFlags });
+        let colors = await helpers.retrieveColors();
+        res.status(200).render('settings', { page: 'settings', featureFlags, colors });
     } catch (error) {
         res.status(404).json({ message: error.message });
     }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,5 +1,7 @@
 const nodemailer = require('nodemailer');
 
+const fs = require('node:fs');
+
 const config = require('./config.json');
 
 const Parameter = require('./models/parameter');
@@ -88,3 +90,23 @@ module.exports.getFeatureFlag = async (feature) => {
         return undefined;
     }
 };
+
+module.exports.retrieveColors = async () => {
+	try {
+		const cssFileLocation = 'src/templates/static/styles/styles.css';
+		const css = fs.readFileSync(cssFileLocation, 'utf8');
+
+		const primaryColorRegEx = /--primary-color: ([#a-fA-F0-9]+);/g;
+
+		const primaryColor = css.match(primaryColorRegEx)[0].replace(primaryColorRegEx, '$1');
+
+		const secondaryColorRegEx = /--secondary-color: ([#a-fA-F0-9]+);/g;
+
+		const secondaryColor = css.match(secondaryColorRegEx)[0].replace(secondaryColorRegEx, '$1');
+
+		return { primaryColor: primaryColor, secondaryColor: secondaryColor };
+	} catch (error) {
+		console.error('Error getting colors:', error);
+		return undefined;
+	}
+}

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -20,5 +20,7 @@ router.delete('/questions', adminController.deleteQuestions);
 router.put('/features/:feature', adminController.changeFeatureFlag);
 router.delete('/features/:feature', adminController.changeFeatureFlag);
 
+router.post('/colors', adminController.changeColors);
+
 
 module.exports = router;

--- a/src/templates/settings.ejs
+++ b/src/templates/settings.ejs
@@ -2,7 +2,7 @@
     <h1>Configuración</h1>
     <p class="lead">Edita los distintos aspectos de la web desde esta página.</p>
 </div>
-<div class="container mt-5">
+<div class="container mt-5 settings-container">
     <div class="row justify-content-center mt-5">
         <div class="col-md-8">
             <div class="card">

--- a/src/templates/settings.ejs
+++ b/src/templates/settings.ejs
@@ -29,5 +29,35 @@
             </div>
         </div>
     </div>
+    <div class="row justify-content-center mt-5">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header">
+                    <h3 class="mb-0 text-center">Colores Personalizados</h3>
+                </div>
+                <div class="card-body">
+                    <form id="colorForm">
+                        <div class="form-group">
+                            <label for="primaryColor">Color Primario</label>
+                            <input type="color" id="primaryColor" name="primaryColor" class="form-control" value="<%= colors.primaryColor %>">
+                        </div>
+                        <div class="form-group">
+                            <label for="secondaryColor">Color Secundario</label>
+                            <input type="color" id="secondaryColor" name="secondaryColor" class="form-control" value="<%= colors.secondaryColor %>">
+                        </div>
+                        <button
+                        type="submit"
+                        class="btn btn-primary mt-3"
+                        hx-post="/api/admin/colors"
+                        hx-trigger="click"
+                        hx-target="#colorForm"
+                        hx-swap="outerHTML"
+                        hx-target-error="#toastr-container"
+                        >Guardar Colores</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 

--- a/src/templates/static/styles/styles.css
+++ b/src/templates/static/styles/styles.css
@@ -150,3 +150,8 @@ span.badge {
     text-align: center;
     vertical-align: middle;
 }
+
+/* Margenes de las secciones de configuración */
+.settings-container {
+    margin-bottom: 30px;
+}

--- a/src/templates/static/styles/styles.css
+++ b/src/templates/static/styles/styles.css
@@ -1,3 +1,8 @@
+:root {
+    --primary-color: #00509b; /* Default primary color */
+    --secondary-color: #ffffff; /* Default secondary color */
+}
+
 body {
     font-family: 'Comfortaa', sans-serif;
 }
@@ -37,12 +42,12 @@ p,
 /* Navbar custom color */
 .bg-daupm {
     --bs-bg-opacity: 1;
-    background-color: #00509B !important;
+    background-color: var(--primary-color) !important;
     /* Using the color scheme of the reference site */
 }
 
 .text-daupm {
-    color: #00509B !important;
+    color: var(--primary-color) !important;
 }
 
 .modal-content {
@@ -127,7 +132,7 @@ span.badge {
 
 /* Cambiar el color de fondo de la columna de checkboxes para mejorar visibilidad */
 .table td:first-child {
-    background-color: #f8f9fa;
+    background-color: var(--secondary-color);
 }
 
 /* Centrar contenido de la columna de checkboxes verticalmente */


### PR DESCRIPTION
This pull request introduces a new feature to allow dynamic customization of primary and secondary colors on the website. The changes include modifications to controllers, helpers, routes, and templates to support this functionality.

### New Feature: Dynamic Color Customization

* [`src/controllers/adminController.js`](diffhunk://#diff-a2e1db54f5ae3a463ba3e7dd6e36fbf42f18cd4ec37611ed082c3f14d0af958dR328-R360): Added a new `changeColors` function to handle updating the primary and secondary colors in the CSS file.
* [`src/helpers.js`](diffhunk://#diff-49ba0c85360693b8e89ae0e0428284a55db749f08f2b9993d26910def646e02fR93-R112): Added a `retrieveColors` function to read and return the current primary and secondary colors from the CSS file.
* [`src/routes/admin.js`](diffhunk://#diff-df328052607698d952e85476358bf83f8f6cf395b843d8f128e0c434ade7b83dR23-R24): Added a new route to handle POST requests for updating colors.
* [`src/templates/settings.ejs`](diffhunk://#diff-6827e79a9d9aa0e91b93401f9ba49f9473adec050c0c29154d1cdfe67d5d9ed8R32-R61): Updated the settings page to include a form for updating the primary and secondary colors.
* [`src/templates/static/styles/styles.css`](diffhunk://#diff-97c253ab58fb41ef820cab17dfbbac72bef95462998e1c777a30f55099cff623R1-R5): Defined CSS variables for primary and secondary colors and updated existing styles to use these variables.