### PR TITLE
Dat 1 improve webpage color customization

### DIFF
--- a/src/controllers/adminController.js
+++ b/src/controllers/adminController.js
@@ -327,13 +327,13 @@ const changeFeatureFlag = async (req, res, next) => {
 
 const changeColors = async (req, res, next) => {
     try {
-        const { primaryColor, secondaryColor } = req.body;
+        const { primaryColor, secondaryColor, primaryButtonColor, secondaryButtonColor } = req.body;
 
-        if (!primaryColor || !secondaryColor) {
-            return next(new BadRequestError('Se deben proporcionar ambos colores.'));
+        if (!primaryColor || !secondaryColor || !primaryButtonColor|| !secondaryButtonColor) {
+            return next(new BadRequestError('Se deben proporcionar todos los colores.'));
         }
 
-        if (!/^#[0-9A-F]{6}$/i.test(primaryColor) || !/^#[0-9A-F]{6}$/i.test(secondaryColor)) {
+        if (!/^#[0-9A-F]{6}$/i.test(primaryColor) || !/^#[0-9A-F]{6}$/i.test(secondaryColor) || !/^#[0-9A-F]{6}$/i.test(primaryButtonColor) || !/^#[0-9A-F]{6}$/i.test(secondaryButtonColor)) {
             return next(new BadRequestError('Los colores proporcionados no son válidos.'));
         }
 
@@ -345,6 +345,8 @@ const changeColors = async (req, res, next) => {
 
             parameter.colors.primary = primaryColor;
             parameter.colors.secondary = secondaryColor;
+            parameter.colors.primaryButton = primaryButtonColor;
+            parameter.colors.secondaryButton = secondaryButtonColor;
           
             parameter.markModified('colors');
             await parameter.save();
@@ -352,7 +354,7 @@ const changeColors = async (req, res, next) => {
             return next(new InternalServerError('Error al guardar los colores en la base de datos.'));
         }
 
-        res.locals.colors = { primary: primaryColor, secondary: secondaryColor };
+        res.locals.colors = { primary: primaryColor, secondary: secondaryColor, primaryButton: primaryButtonColor, secondaryButton: secondaryButtonColor };
 
 
         req.toastr.success('Colores de la página actualizados correctamente.');

--- a/src/databaseGenScriptExample.js
+++ b/src/databaseGenScriptExample.js
@@ -106,7 +106,9 @@ db.parameters.insert({
     },
     colors: {
         primary: '#00509b',
-        secondary: '#ffffff',
+        secondary: '#00509b',
+        primaryButton: '#00509b',
+        secondaryButton: '#00509b',
     },
     featureFlags: {
         'questions': true,

--- a/src/templates/layout.ejs
+++ b/src/templates/layout.ejs
@@ -27,6 +27,8 @@
         :root {
             --primary-color: <%= colors.primary %>;
             --secondary-color: <%= colors.secondary %>;
+            --primary-button-color: <%= colors.primaryButton %>;
+            --secondary-button-color: <%= colors.secondaryButton %>;
         }
     </style>
 </head>
@@ -74,7 +76,7 @@
 
     <div id="toastr-container"><%- toasts %></div>
 
-    <footer class="bg-daupm text-white py-4 mt-auto">
+    <footer class="bg-daupm text-white p-4 mt-auto">
         <div class="container">
             <div class="row">
                 <!-- Primera columna -->
@@ -87,7 +89,6 @@
                         <li><strong>Email:</strong> <a href="mailto:<%= texts.email %>" class="text-white"><%= texts.email %></a></li>
                         <li><strong>Web:</strong> <a href="http://<%= texts.web %>" class="text-white"><%= texts.web %></a></li>
                     </ul>
-
                 </div>
                 <!-- Segunda columna -->
                 <div class="col-md-6 mb-3">

--- a/src/templates/settings.ejs
+++ b/src/templates/settings.ejs
@@ -57,6 +57,14 @@
                             <label for="secondaryColor">Color Secundario</label>
                             <input type="color" id="secondaryColor" name="secondaryColor" class="form-control" value="<%= colors.secondary %>">
                         </div>
+                        <div class="form-group mb-4">
+                            <label for="primaryButtonColor">Color Botón Primario</label>
+                            <input type="color" id="primaryButtonColor" name="primaryButtonColor" class="form-control" value="<%= colors.primaryButton %>">
+                        </div>
+                        <div class="form-group mb-4">
+                            <label for="secondaryButtonColor">Color Botón Secundario</label>
+                            <input type="color" id="secondaryButtonColor" name="secondaryButtonColor" class="form-control" value="<%= colors.secondaryButton %>">
+                        </div>
                         <button
                         type="submit"
                         class="btn btn-primary mt-3"
@@ -93,6 +101,7 @@
                                     </div>
                                 </div>
                             </div>
+                        </div>
                         <div class="form-group mb-4">
                             <label for="headerText">Texto central de página</label>
                             <div class="card">
@@ -138,7 +147,6 @@
                                     </div>
                                 </div>
                             </div>
-
                         </div>
                         <div class="form-group mb-4">
                             <label for="socialMedia">Redes Sociales</label>

--- a/src/templates/settings.ejs
+++ b/src/templates/settings.ejs
@@ -1,251 +1,325 @@
-<% const icons = {
-    x: "bi bi-twitter-x",
-    instagram: "bi bi-instagram",
-    youtube: "bi bi-youtube",
-    facebook: "bi bi-facebook",
-    tiktok: "bi bi-tiktok",
-    telegram: "bi bi-telegram",
-    whatsapp: "bi bi-whatsapp",
-    linkedin: "bi bi-linkedin"
-  } %>
-<div class="container mt-5 text-center">
-    <h1>Configuración</h1>
-    <p class="lead">Edita los distintos aspectos de la web desde esta página.</p>
-</div>
-<div class="container mt-5 settings-container">
-    <div class="row justify-content-center mt-5">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header">
-                    <h3 class="mb-0 text-center">Feature Flags</h3>
+<% const icons={ x: "bi bi-twitter-x" , instagram: "bi bi-instagram" , youtube: "bi bi-youtube" ,
+    facebook: "bi bi-facebook" , tiktok: "bi bi-tiktok" , telegram: "bi bi-telegram" , whatsapp: "bi bi-whatsapp" ,
+    linkedin: "bi bi-linkedin" } %>
+    <div class="container mt-5 text-center">
+        <h1>Configuración</h1>
+        <p class="lead">Edita los distintos aspectos de la web desde esta página.</p>
+    </div>
+
+    <div class="container settings-container row justify-content-center">
+        <div class="col-md-6">
+            <!-- Feature Flags Card -->
+            <div class="row justify-content-center mt-5">
+                <div class="col">
+                    <div class="card">
+                        <div class="card-header">
+                            <h4 class="mt-2 mb-0 text-center">Feature Flags</h3>
+                        </div>
+                        <div class="card-body">
+                            <div class="table-responsive">
+                                <table class="table">
+                                    <thead>
+                                        <tr>
+                                            <th>Funcionalidad</th>
+                                            <th class="text-center">Estado</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <% for (const [flag, featureValue] of Object.entries(featureFlags)) { %>
+                                            <%- include('fragments/admin/featureRow', { flag, featureValue }) %>
+                                                <% } %>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
                 </div>
-                <div class="card-body">
-                    <div class="table-responsive">
-                        <table class="table">
-                            <thead>
-                                <tr>
-                                    <th>Funcionalidad</th>
-                                    <th class="text-center">Estado</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <% for (const [flag, featureValue] of Object.entries(featureFlags)) { %>
-                                    <%- include('fragments/admin/featureRow', { flag, featureValue }) %>
-                                <% } %>
-                            </tbody>
-                        </table>
+            </div>
+
+            <!-- Color settings -->
+            <div class="row justify-content-center mt-5">
+                <div class="col">
+                    <div class="card">
+                        <div class="card-header">
+                            <h4 class="mt-2 mb-0 text-center">Colores Personalizados</h3>
+                        </div>
+                        <div class="card-body">
+                            <form id="colorForm">
+                                <div class="form-group mb-4">
+                                    <label for="primaryColor">Color Primario</label>
+                                    <input type="color" id="primaryColor" name="primaryColor" class="form-control"
+                                        value="<%= colors.primary %>">
+                                </div>
+                                <div class="form-group mb-4">
+                                    <label for="secondaryColor">Color Secundario</label>
+                                    <input type="color" id="secondaryColor" name="secondaryColor" class="form-control"
+                                        value="<%= colors.secondary %>">
+                                </div>
+                                <div class="form-group mb-4">
+                                    <label for="primaryButtonColor">Color Botón Primario</label>
+                                    <input type="color" id="primaryButtonColor" name="primaryButtonColor"
+                                        class="form-control" value="<%= colors.primaryButton %>">
+                                </div>
+                                <div class="form-group mb-4">
+                                    <label for="secondaryButtonColor">Color Botón Secundario</label>
+                                    <input type="color" id="secondaryButtonColor" name="secondaryButtonColor"
+                                        class="form-control" value="<%= colors.secondaryButton %>">
+                                </div>
+                                <button type="submit" class="btn btn-primary mt-3" hx-post="/api/admin/colors"
+                                    hx-trigger="click" hx-target="#colorForm" hx-swap="outerHTML"
+                                    hx-target-error="#toastr-container">Guardar Colores</button>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-md-6">
+            <!-- Text Settings -->
+            <div class="row justify-content-center mt-5">
+                <div class="col">
+                    <div class="card">
+                        <div class="card-header">
+                            <h4 class="mt-2 mb-0 text-center">Configuración de Texto</h3>
+                        </div>
+                        <div class="card-body">
+                            <form id="textForm">
+                                <div class="form-group mb-3">
+                                    <label for="headerText">Texto de pestaña de navegador</label>
+                                    <div class="card">
+                                        <div class="card-body">
+                                            <div class="form-row ">
+                                                <div class="form-group ">
+                                                    <input type="text" id="pageTitle" name="pageTitle"
+                                                        class="form-control" value="<%= texts.pageTitle %>">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="accordion mb-3" id="centralTextAccordion">
+                                    <div class="accordion-item">
+                                        <h2 class="accordion-header">
+                                            <button class="accordion-button collapsed" type="button"
+                                                data-bs-toggle="collapse" data-bs-target="#centralTextCollapse"
+                                                aria-expanded="false" aria-controls="centralTextCollapse">
+                                                Texto central de página
+                                            </button>
+                                        </h2>
+                                        <div id="centralTextCollapse" class="accordion-collapse collapse"
+                                            data-bs-parent="#centralTextAccordion">
+                                            <div class="accordion-body">
+                                                <div class="form-row">
+                                                    <div class="form-group mb-4">
+                                                        <label for="headerTitle">Título</label>
+                                                        <input type="text" id="headerTitle" name="headerTitle"
+                                                            class="form-control" value="<%= texts.headerTitle %>">
+                                                    </div>
+                                                    <div class="form-group">
+                                                        <label for="headerSubtitle">Subtítulo</label>
+                                                        <input type="text" id="headerSubtitle" name="headerSubtitle"
+                                                            class="form-control" value="<%= texts.headerSubtitle %>">
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="accordion mb-3" id="footerTextAccordion">
+                                    <div class="accordion-item">
+                                        <h2 class="accordion-header">
+                                            <button class="accordion-button collapsed" type="button"
+                                                data-bs-toggle="collapse" data-bs-target="#footerTextCollapse"
+                                                aria-expanded="false" aria-controls="footerTextCollapse">
+                                                Texto de Pie de Página
+                                            </button>
+                                        </h2>
+                                        <div id="footerTextCollapse" class="accordion-collapse collapse"
+                                            data-bs-parent="#footerTextAccordion">
+                                            <div class="accordion-body">
+                                                <div class="form-row">
+                                                    <div class="form-group mb-4">
+                                                        <label for="delegationName">Nombre de la Delegación</label>
+                                                        <input type="text" id="delegationName" name="delegationName"
+                                                            class="form-control" value="<%= texts.delegationName %>">
+                                                    </div>
+                                                    <div class="form-group mb-4">
+                                                        <label for="phoneNumber">Número de Teléfono</label>
+                                                        <input type="text" id="phoneNumber" name="phoneNumber"
+                                                            class="form-control" value="<%= texts.phoneNumber %>">
+                                                    </div>
+                                                    <div class="form-group mb-4">
+                                                        <label for="email">Correo Electrónico</label>
+                                                        <input type="email" id="email" name="email" class="form-control"
+                                                            value="<%= texts.email %>">
+                                                    </div>
+                                                    <div class="form-group mb-4">
+                                                        <label for="address">Página Web</label>
+                                                        <input type="text" id="web" name="web" class="form-control"
+                                                            value="<%= texts.web %>">
+                                                    </div>
+                                                    <div class="form-group">
+                                                        <label for="email">Correo Electrónico de las elecciones</label>
+                                                        <input type="email" id="emailElections" name="emailElections"
+                                                            class="form-control" value="<%= texts.emailElections %>">
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="accordion mb-3" id="socialMediaAccordion">
+                                    <div class="accordion-item">
+                                        <h2 class="accordion-header">
+                                            <button class="accordion-button collapsed" type="button"
+                                                data-bs-toggle="collapse" data-bs-target="#socialMediaCollapse"
+                                                aria-expanded="false" aria-controls="socialMediaCollapse">
+                                                Redes Sociales
+                                            </button>
+                                        </h2>
+                                        <div id="socialMediaCollapse" class="accordion-collapse collapse"
+                                            data-bs-parent="#socialMediaAccordion">
+                                            <div class="accordion-body">
+                                                <div class="form-group mb-3">
+                                                    <div class="card">
+                                                        <div class="card-body" id="socialMediaContainer">
+                                                            <% if(texts.socialMedia.length==0) { %>
+                                                                <div class="form-row mb-4">
+                                                                    <div class="col mb-4">
+                                                                        <label for="socialMediaIcon0">Icono</label>
+                                                                        <select id="socialMediaIcon0"
+                                                                            name="socialMedia[0][icon]"
+                                                                            class="form-control">
+                                                                            <% for(let key in icons) { %>
+                                                                                <option value="<%= icons[key] %>">
+                                                                                    <%= key.charAt(0).toUpperCase() +
+                                                                                        key.slice(1) %>
+                                                                                </option>
+                                                                                <% } %>
+                                                                        </select>
+                                                                    </div>
+                                                                    <div class="col mb-4">
+                                                                        <label for="socialMediaName0">Nombre</label>
+                                                                        <input type="text" id="socialMediaName0"
+                                                                            name="socialMedia[0][name]"
+                                                                            class="form-control" value="">
+                                                                    </div>
+                                                                    <div class="col mb-4">
+                                                                        <label for="socialMediaLink0">Enlace</label>
+                                                                        <input type="text" id="socialMediaLink0"
+                                                                            name="socialMedia[0][link]"
+                                                                            class="form-control" value="">
+                                                                    </div>
+                                                                </div>
+                                                                <% } else { %>
+                                                                    <% let index=0; %>
+                                                                        <% for(let social in texts.socialMedia) { %>
+                                                                            <% if(social> 0) { %>
+                                                                                <div class="social-media-separator">
+                                                                                </div>
+                                                                                <% } %>
+                                                                                    <div class="form-row mb-4">
+                                                                                        <div class="col mb-4">
+                                                                                            <label
+                                                                                                for="socialMediaIcon<%= index %>">Icono</label>
+                                                                                            <select
+                                                                                                id="socialMediaIcon<%= index %>"
+                                                                                                name="socialMedia[<%= index %>][icon]"
+                                                                                                class="form-control"
+                                                                                                selected="<%= texts.socialMedia[social].icon %>">
+                                                                                                <% for(let key in icons)
+                                                                                                    { %>
+                                                                                                    <% if(icons[key]==texts.socialMedia[social].icon)
+                                                                                                        { %>
+                                                                                                        <option
+                                                                                                            value="<%= icons[key] %>"
+                                                                                                            selected>
+                                                                                                            <%= key.charAt(0).toUpperCase()
+                                                                                                                +
+                                                                                                                key.slice(1)
+                                                                                                                %>
+                                                                                                        </option>
+                                                                                                        <% } else { %>
+                                                                                                            <option
+                                                                                                                value="<%= icons[key] %>">
+                                                                                                                <%= key.charAt(0).toUpperCase()
+                                                                                                                    +
+                                                                                                                    key.slice(1)
+                                                                                                                    %>
+                                                                                                            </option>
+                                                                                                            <% } %>
+                                                                                                                <% } %>
+                                                                                            </select>
+                                                                                        </div>
+                                                                                        <div class="col mb-4">
+                                                                                            <label
+                                                                                                for="socialMediaName<%= index %>">Nombre</label>
+                                                                                            <input type="text"
+                                                                                                id="socialMediaName<%= index %>"
+                                                                                                name="socialMedia[<%= index %>][name]"
+                                                                                                class="form-control"
+                                                                                                value="<%= texts.socialMedia[social].name %>">
+                                                                                        </div>
+                                                                                        <div class="col mb-4">
+                                                                                            <label
+                                                                                                for="socialMediaLink<%= index %>">Enlace</label>
+                                                                                            <input type="text"
+                                                                                                id="socialMediaLink<%= index %>"
+                                                                                                name="socialMedia[<%= index %>][link]"
+                                                                                                class="form-control"
+                                                                                                value="<%= texts.socialMedia[social].link %>">
+                                                                                        </div>
+                                                                                        <div
+                                                                                            class="col-auto mb-4 d-flex align-items-end">
+                                                                                            <button type="button"
+                                                                                                class="btn btn-danger"
+                                                                                                onclick="removeSocialMedia(this)">
+                                                                                                <i
+                                                                                                    class="bi bi-trash"></i>
+                                                                                            </button>
+                                                                                        </div>
+                                                                                    </div>
+                                                                                    <% index++ %>
+                                                                                        <% } %>
+                                                                                            <% } %>
+                                                        </div>
+                                                        <button type="button" class="btn btn-secondary mt-3"
+                                                            id="addSocialMediaButton">
+                                                            Añadir red social</button>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <button type="submit" class="btn btn-primary mt-3" hx-post="/api/admin/text"
+                                    hx-trigger="click" hx-target="#textForm" hx-swap="outerHTML"
+                                    hx-target-error="#toastr-container">Guardar
+                                    Texto</button>
+                            </form>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
 
-    <!-- Color settings -->
-    <div class="row justify-content-center mt-5">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header">
-                    <h3 class="mb-0 text-center">Colores Personalizados</h3>
-                </div>
-                <div class="card-body">
-                    <form id="colorForm">
-                        <div class="form-group mb-4">
-                            <label for="primaryColor">Color Primario</label>
-                            <input type="color" id="primaryColor" name="primaryColor" class="form-control" value="<%= colors.primary %>">
-                        </div>
-                        <div class="form-group mb-4">
-                            <label for="secondaryColor">Color Secundario</label>
-                            <input type="color" id="secondaryColor" name="secondaryColor" class="form-control" value="<%= colors.secondary %>">
-                        </div>
-                        <div class="form-group mb-4">
-                            <label for="primaryButtonColor">Color Botón Primario</label>
-                            <input type="color" id="primaryButtonColor" name="primaryButtonColor" class="form-control" value="<%= colors.primaryButton %>">
-                        </div>
-                        <div class="form-group mb-4">
-                            <label for="secondaryButtonColor">Color Botón Secundario</label>
-                            <input type="color" id="secondaryButtonColor" name="secondaryButtonColor" class="form-control" value="<%= colors.secondaryButton %>">
-                        </div>
-                        <button
-                        type="submit"
-                        class="btn btn-primary mt-3"
-                        hx-post="/api/admin/colors"
-                        hx-trigger="click"
-                        hx-target="#colorForm"
-                        hx-swap="outerHTML"
-                        hx-target-error="#toastr-container"
-                        >Guardar Colores</button>
-                    </form>
-                </div>
-            </div>
-        </div>
-    </div>
+    <script>
+        document.getElementById('addSocialMediaButton').addEventListener('click', function () {
+            const container = document.getElementById('socialMediaContainer');
+            const index = container.children.length;
 
-    <!-- Text Settings -->
-    <div class="row justify-content-center mt-5">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header">
-                    <h3 class="mb-0 text-center">Configuración de Texto</h3>
-                </div>
-                <div class="card-body">
-                    <form id="textForm">
-                        <div class="form-group mb-4">
-                            <label for="headerText">Texto de pestaña de navegador</label>
-                            <div class="card">
-                                <div class="card-body">
-                                    <div class="form-row mb-4">
-                                        <div class="form-group mb-4">
-                                            <label for="pageTitle">Título de pestaña</label>
-                                            <input type="text" id="pageTitle" name="pageTitle" class="form-control" value="<%= texts.pageTitle %>">
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="form-group mb-4">
-                            <label for="headerText">Texto central de página</label>
-                            <div class="card">
-                                <div class="card-body">
-                                    <div class="form-row mb-4">
-                                        <div class="form-group mb-4">
-                                            <label for="headerTitle">Título</label>
-                                            <input type="text" id="headerTitle" name="headerTitle" class="form-control" value="<%= texts.headerTitle %>">
-                                        </div>
-                                        <div class="form-group mb-4">
-                                            <label for="headerSubtitle">Subtítulo</label>
-                                            <input type="text" id="headerSubtitle" name="headerSubtitle" class="form-control" value="<%= texts.headerSubtitle %>">
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="form-group mb-4">
-                            <label for="footerText">Texto de Pie de Página</label>
-                            <div class="card">
-                                <div class="card-body">
-                                    <div class="form-row mb-4">
-                                        <div class="form-group mb-4">
-                                            <label for="delegationName">Nombre de la Delegación</label>
-                                            <input type="text" id="delegationName" name="delegationName" class="form-control" value="<%= texts.delegationName %>">
-                                        </div>
-                                        <div class="form-group mb-4">
-                                            <label for="phoneNumber">Número de Teléfono</label>
-                                            <input type="text" id="phoneNumber" name="phoneNumber" class="form-control" value="<%= texts.phoneNumber %>">
-                                        </div>
-                                        <div class="form-group mb-4">
-                                            <label for="email">Correo Electrónico</label>
-                                            <input type="email" id="email" name="email" class="form-control" value="<%= texts.email %>">
-                                        </div>
-                                        <div class="form-group mb-4">
-                                            <label for="address">Página Web</label>
-                                            <input type="text" id="web" name="web" class="form-control" value="<%= texts.web %>">
-                                        </div>
-                                        <div class="form-group mb-4">
-                                            <label for="email">Correo Electrónico de las elecciones</label>
-                                            <input type="email" id="emailElections" name="emailElections" class="form-control" value="<%= texts.emailElections %>">
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="form-group mb-4">
-                            <label for="socialMedia">Redes Sociales</label>
-                            <div class="card">
-                                <div class="card-body" id="socialMediaContainer">
-                                <% if(texts.socialMedia.length == 0) { %>
-                                    <div class="form-row mb-4">
-                                        <div class="col mb-4">
-                                            <label for="socialMediaIcon0">Icono</label>
-                                            <select id="socialMediaIcon0" name="socialMedia[0][icon]" class="form-control">
-                                                <% for(let key in icons) { %>
-                                                    <option value="<%= icons[key] %>"><%= key.charAt(0).toUpperCase() + key.slice(1) %></option>
-                                                <% } %>
-                                            </select>
-                                        </div>
-                                        <div class="col mb-4">
-                                            <label for="socialMediaName0">Nombre</label>
-                                            <input type="text" id="socialMediaName0" name="socialMedia[0][name]" class="form-control" value="">
-                                        </div>
-                                        <div class="col mb-4">
-                                            <label for="socialMediaLink0">Enlace</label>
-                                            <input type="text" id="socialMediaLink0" name="socialMedia[0][link]" class="form-control" value="">
-                                        </div>
-                                    </div> 
-                                <% } else { %>
-                                        <% let index = 0; %>
-                                        <% for(let social in texts.socialMedia) { %>
-                                            <% if(social > 0) { %>
-                                                <div class="social-media-separator"></div>
-                                            <% } %>
-                                            <div class="form-row mb-4">
-                                                <div class="col mb-4">
-                                                    <label for="socialMediaIcon<%= index %>">Icono</label>
-                                                    <select id="socialMediaIcon<%= index %>" name="socialMedia[<%= index %>][icon]" class="form-control" selected="<%= texts.socialMedia[social].icon %>">
-                                                        <% for(let key in icons) { %>
-                                                            <% if(icons[key] == texts.socialMedia[social].icon) { %>
-                                                                <option value="<%= icons[key] %>" selected><%= key.charAt(0).toUpperCase() + key.slice(1) %></option>
-                                                            <% } else { %>
-                                                                <option value="<%= icons[key] %>"><%= key.charAt(0).toUpperCase() + key.slice(1) %></option>
-                                                            <% } %>
-                                                        <% } %>
-                                                    </select>
-                                                </div>
-                                                <div class="col mb-4">
-                                                    <label for="socialMediaName<%= index %>">Nombre</label>
-                                                    <input type="text" id="socialMediaName<%= index %>" name="socialMedia[<%= index %>][name]" class="form-control" value="<%= texts.socialMedia[social].name %>">
-                                                </div>
-                                                <div class="col mb-4">
-                                                    <label for="socialMediaLink<%= index %>">Enlace</label>
-                                                    <input type="text" id="socialMediaLink<%= index %>" name="socialMedia[<%= index %>][link]" class="form-control" value="<%= texts.socialMedia[social].link %>">
-                                                </div>
-                                                <div class="col-auto mb-4 d-flex align-items-end">
-                                                    <button type="button" class="btn btn-danger" onclick="removeSocialMedia(this)">
-                                                        <i class="bi bi-trash"></i>
-                                                    </button>
-                                                </div>
-                                            </div>
-                                        <% index++ %>
-                                        <% } %>
-                                <% } %>
-                                </div>
-                                <button
-                                type="button"
-                                class="btn btn-secondary mt-3"
-                                id="addSocialMediaButton">
-                                Añadir red social</button>
-                            </div>
-                        </div>
-                        <button
-                        type="submit"
-                        class="btn btn-primary mt-3"
-                        hx-post="/api/admin/text"
-                        hx-trigger="click"
-                        hx-target="#textForm"
-                        hx-swap="outerHTML"
-                        hx-target-error="#toastr-container"
-                        >Guardar Texto</button>
-                    </form>
-                </div>
-            </div>
-        </div>
-    </div>              
-</div>
+            // Añadir separador si no es el primer elemento
+            if (index > 0) {
+                const separator = document.createElement('div');
+                separator.className = 'social-media-separator';
+                container.appendChild(separator);
+            }
 
-<script>
-document.getElementById('addSocialMediaButton').addEventListener('click', function() {
-    const container = document.getElementById('socialMediaContainer');
-    const index = container.children.length;
-    
-    // Añadir separador si no es el primer elemento
-    if (index > 0) {
-        const separator = document.createElement('div');
-        separator.className = 'social-media-separator';
-        container.appendChild(separator);
-    }
-
-    const newField = document.createElement('div');
-    newField.className = 'form-row mb-4';
-    newField.innerHTML = `
+            const newField = document.createElement('div');
+            newField.className = 'form-row mb-4';
+            newField.innerHTML = `
         <div class="col mb-4">
             <label for="socialMediaIcon${index}">Icono</label>
             <select id="socialMediaIcon${index}" name="socialMedia[${index}][icon]" class="form-control">
@@ -273,45 +347,44 @@ document.getElementById('addSocialMediaButton').addEventListener('click', functi
             </button>
         </div>
     `;
-    container.appendChild(newField);
-});
+            container.appendChild(newField);
+        });
 
-function removeSocialMedia(button) {
-    const row = button.closest('.form-row');
-    const separator = row.previousElementSibling;
-    if (separator && separator.className === 'social-media-separator') {
-        separator.remove();
-    }
-    row.remove();
-    reindexSocialMedia();
-}
+        function removeSocialMedia(button) {
+            const row = button.closest('.form-row');
+            const separator = row.previousElementSibling;
+            if (separator && separator.className === 'social-media-separator') {
+                separator.remove();
+            }
+            row.remove();
+            reindexSocialMedia();
+        }
 
-// Debido a que los elementos se eliminan y añaden dinámicamente, es necesario reindexar los elementos.
-// Si no se hace esto, puede dar problemas al enviar el formulario, ya que podrían haber elementos con
-// el mismo nombre.
+        // Debido a que los elementos se eliminan y añaden dinámicamente, es necesario reindexar los elementos.
+        // Si no se hace esto, puede dar problemas al enviar el formulario, ya que podrían haber elementos con
+        // el mismo nombre.
 
-function reindexSocialMedia() {
-    const container = document.getElementById('socialMediaContainer');
-    const rows = container.getElementsByClassName('form-row');
-    
-    Array.from(rows).forEach((row, index) => {
-        const select = row.querySelector('select');
-        const inputs = row.querySelectorAll('input');
-        const labels = row.querySelectorAll('label');
-        
-        select.id = `socialMediaIcon${index}`;
-        select.name = `socialMedia[${index}][icon]`;
-        
-        inputs[0].id = `socialMediaName${index}`;
-        inputs[0].name = `socialMedia[${index}][name]`;
-        
-        inputs[1].id = `socialMediaLink${index}`;
-        inputs[1].name = `socialMedia[${index}][link]`;
+        function reindexSocialMedia() {
+            const container = document.getElementById('socialMediaContainer');
+            const rows = container.getElementsByClassName('form-row');
 
-        labels[0].htmlFor = `socialMediaIcon${index}`;
-        labels[1].htmlFor = `socialMediaName${index}`;
-        labels[2].htmlFor = `socialMediaLink${index}`;
-    });
-}
-</script>
+            Array.from(rows).forEach((row, index) => {
+                const select = row.querySelector('select');
+                const inputs = row.querySelectorAll('input');
+                const labels = row.querySelectorAll('label');
 
+                select.id = `socialMediaIcon${index}`;
+                select.name = `socialMedia[${index}][icon]`;
+
+                inputs[0].id = `socialMediaName${index}`;
+                inputs[0].name = `socialMedia[${index}][name]`;
+
+                inputs[1].id = `socialMediaLink${index}`;
+                inputs[1].name = `socialMedia[${index}][link]`;
+
+                labels[0].htmlFor = `socialMediaIcon${index}`;
+                labels[1].htmlFor = `socialMediaName${index}`;
+                labels[2].htmlFor = `socialMediaLink${index}`;
+            });
+        }
+    </script>

--- a/src/templates/static/styles/styles.css
+++ b/src/templates/static/styles/styles.css
@@ -37,12 +37,22 @@ p,
 /* Navbar custom color */
 .bg-daupm {
     --bs-bg-opacity: 1;
-    background-color: var(--primary-color) !important;
+    background: linear-gradient(to right, var(--primary-color), var(--secondary-color)) !important;
     /* Using the color scheme of the reference site */
 }
 
 .text-daupm {
     color: var(--primary-color) !important;
+}
+
+.btn-primary {
+    background-color: var(--primary-button-color);
+    border-color: var(--primary-button-color);
+}
+
+.btn-primary:hover {
+    background-color: var(--secondary-button-color);
+    border-color: var(--secondary-button-color);
 }
 
 .modal-content {
@@ -120,15 +130,11 @@ span.badge {
 
 /* Aumentar contraste de las checkboxes */
 .table .form-check-input:checked {
-    background-color: #007bff;
+    background-color: var(--primary-button-color);
     /* Color azul para las checkboxes seleccionadas */
-    border-color: #007bff;
+    border-color: var(--primary-button-color);
 }
 
-/* Cambiar el color de fondo de la columna de checkboxes para mejorar visibilidad */
-.table td:first-child {
-    background-color: var(--secondary-color);
-}
 
 /* Centrar contenido de la columna de checkboxes verticalmente */
 .table td {

--- a/src/templates/static/styles/styles.css
+++ b/src/templates/static/styles/styles.css
@@ -55,6 +55,12 @@ p,
     border-color: var(--secondary-button-color);
 }
 
+.accordion-button:not(.collapsed) {
+    color: #ffffff;
+    background-color: var(--primary-button-color);
+    box-shadow: inset 0 calc(-1* var(--primary-button-color)) 0 var(--primary-button-color);
+}
+
 .modal-content {
     border-radius: 10px;
 }

--- a/src/templates/static/styles/timeline.css
+++ b/src/templates/static/styles/timeline.css
@@ -1,8 +1,8 @@
 .timeline {
-    border-left: 3px solid #00509B;
+    border-left: 3px solid var(--primary-color);
     border-bottom-right-radius: 4px;
     border-top-right-radius: 4px;
-    background: rgba(114, 124, 245, 0.09);
+    background: rgba(var(--secondary-color), 0.09);
     margin: 0 auto;
     letter-spacing: 0.2px;
     position: relative;
@@ -76,8 +76,8 @@
 }
 
 .timeline .event:after {
-    -webkit-box-shadow: 0 0 0 3px #00509B;
-    box-shadow: 0 0 0 3px #00509B;
+    -webkit-box-shadow: 0 0 0 3px var(--primary-color);
+    box-shadow: 0 0 0 3px var(--primary-color);
     left: -55.8px;
     background: #fff;
     border-radius: 50%;
@@ -100,7 +100,7 @@
     border-top-right-radius: 0;
     border-bottom-left-radius: 4px;
     border-top-left-radius: 4px;
-    border-right: 3px solid #00509B;
+    border-right: 3px solid var(--primary-color);
 }
 
 .rtl .timeline .event::before {


### PR DESCRIPTION
The settings page for administrators has been modified to implement further customization.

### Settings page

Settings cards have been rearraged into two collumns.

### Website colours

Hard-coded colors have been removed from the style except for the graph colours in the process view.

Boostrap buttons and accordions have been modified to match the personalised colours.
The header and footer now support a gradient between the primary and secondary colours.

Two new variables have been added to the db, the databaseGenScriptExample has been modified accordingly.

### Website text

The settings page form for website text has been modified to be collapsible.

